### PR TITLE
[#26] Swagger-helper functions

### DIFF
--- a/cake-slayer.cabal
+++ b/cake-slayer.cabal
@@ -29,6 +29,8 @@ common common-options
                      , relude (Relude as Prelude
                               , Relude.Extra.Bifunctor
                               , Relude.Extra.CallStack
+                              , Relude.Extra.Lens
+                              , Relude.Extra.Type
                               , Relude.Unsafe
                               )
 
@@ -74,6 +76,7 @@ library
                          CakeSlayer.Monad
                          CakeSlayer.Password
                          CakeSlayer.Random
+                         CakeSlayer.Swagger
                          CakeSlayer.Time
 
   build-depends:       aeson ^>= 1.4
@@ -91,6 +94,7 @@ library
                      , random ^>= 1.1
                      , resource-pool ^>= 0.2.3.2
                      , scientific ^>= 0.3.6
+                     , swagger2 ^>= 2.4
                      , time >= 1.8 && < 1.10
                      , unliftio-core ^>= 0.1.2.0
                      , unordered-containers ^>= 0.2.10.0

--- a/src/CakeSlayer/Swagger.hs
+++ b/src/CakeSlayer/Swagger.hs
@@ -1,0 +1,78 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+
+{- | Helper functions to write @swagger@ instances easier.
+-}
+
+module CakeSlayer.Swagger
+       ( schemaRef
+       , namedSchema
+       , declareSingleFieldSchema
+       ) where
+
+import Data.Swagger (Definitions, HasType (type_), NamedSchema (NamedSchema), Referenced, Schema,
+                     SwaggerType (SwaggerObject), ToSchema, declareSchemaRef, properties, required)
+import Data.Swagger.Declare (Declare)
+import Relude.Extra.Lens ((.~))
+import Relude.Extra.Type (typeName)
+
+{- | Shorter version of 'declareSchemaRef'. So instead of
+
+@
+declareSchemaRef (Proxy @MyType)
+@
+
+you can write
+
+@
+schemaRef @MyType
+@
+-}
+schemaRef
+    :: forall t . ToSchema t
+    => Declare (Definitions Schema) (Referenced Schema)
+schemaRef = declareSchemaRef (Proxy @t)
+
+{- | Helper function to return named schemas. So instead of:
+
+@
+pure $ NamedSchema (Just "LoginResponse") $ mempty
+    & type_ .~ SwaggerObject
+    & properties .~ fromList
+        [ ("jwtToken", jwtTokenSchema)
+        ]
+    & required .~ ["jwtToken"]
+@
+
+you will use it like:
+
+@
+'namedSchema' @LoginResponse $ \s -> s
+    & properties .~ fromList
+        [("jwtToken", jwtTokenSchema)]
+    & required .~ ["jwtToken"]
+@
+-}
+namedSchema
+    :: forall t f .
+       (Typeable t, Applicative f)
+    => (Schema -> Schema)
+    -> f NamedSchema
+namedSchema updateSchema = pure $ NamedSchema
+    (Just $ typeName @t)
+    (updateSchema $ mempty & type_ .~ Just SwaggerObject)
+
+{- | Helper function to declare 'ToSchema' instances for data types that contain
+only single field.
+-}
+declareSingleFieldSchema
+    :: forall field a proxy .
+       (ToSchema field, Typeable a)
+    => Text
+    -> proxy a
+    -> Declare (Definitions Schema) NamedSchema
+declareSingleFieldSchema fieldName _ = do
+    fieldsSchema <- schemaRef @field
+    namedSchema @a $ \s -> s
+        & properties .~ fromList
+            [(fieldName, fieldsSchema)]
+        & required .~ [fieldName]

--- a/src/CakeSlayer/Swagger.hs
+++ b/src/CakeSlayer/Swagger.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
+{- HLINT ignore "Use ?~" -}
 
 {- | Helper functions to write @swagger@ instances easier.
 -}
@@ -14,6 +15,7 @@ import Data.Swagger (Definitions, HasType (type_), NamedSchema (NamedSchema), Re
 import Data.Swagger.Declare (Declare)
 import Relude.Extra.Lens ((.~))
 import Relude.Extra.Type (typeName)
+
 
 {- | Shorter version of 'declareSchemaRef'. So instead of
 


### PR DESCRIPTION
Resolves #26

One more use case to lenses from `relude`: when the library API is built around lenses, but we don't want to bring either `microlens` or `lens` to our framework.