### PR TITLE
No need to hSetEncoding stdout/stderr utf8 anymore

### DIFF
--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,7 +1,6 @@
 module Main (main) where
 
 import Hedgehog (Group (..), checkParallel)
-import System.IO (hSetEncoding, utf8)
 
 import CakeSlayer.Jwt (decodeIntIdPayload, decodeTextIdPayload, encodeIntIdPayload,
                        encodeTextIdPayload)
@@ -24,9 +23,5 @@ hedgehogTests = Group "Roundtrip properties"
     named = (,)
 
 main :: IO ()
-main =  do
-    -- fix terminal encoding
-    hSetEncoding stdout utf8
-    hSetEncoding stderr utf8
-
+main =
     ifM (checkParallel hedgehogTests) exitSuccess exitFailure


### PR DESCRIPTION
This is done automatically on Hedgehog v0.6.1 and newer (v1.0.1 current):
https://github.com/hedgehogqa/haskell-hedgehog/pull/218/files